### PR TITLE
refactor: 컨트롤러 리팩토링

### DIFF
--- a/src/main/java/techcourse/fakebook/controller/ArticleApiController.java
+++ b/src/main/java/techcourse/fakebook/controller/ArticleApiController.java
@@ -30,7 +30,7 @@ public class ArticleApiController {
     @PostMapping
     public ResponseEntity<ArticleResponse> create(ArticleRequest articleRequest, @SessionUser UserOutline userOutline) {
         ArticleResponse articleResponse = articleService.save(articleRequest, userOutline);
-        return ResponseEntity.created(URI.create("/api/articles")).body(articleResponse);
+        return ResponseEntity.created(URI.create("/api/articles/" + articleResponse.getId())).body(articleResponse);
     }
 
     @PutMapping("/{id}")

--- a/src/main/java/techcourse/fakebook/controller/ArticleApiController.java
+++ b/src/main/java/techcourse/fakebook/controller/ArticleApiController.java
@@ -15,7 +15,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/articles")
 public class ArticleApiController {
-    private ArticleService articleService;
+    private final ArticleService articleService;
 
     public ArticleApiController(ArticleService articleService) {
         this.articleService = articleService;

--- a/src/main/java/techcourse/fakebook/controller/ArticleApiController.java
+++ b/src/main/java/techcourse/fakebook/controller/ArticleApiController.java
@@ -1,7 +1,6 @@
 package techcourse.fakebook.controller;
 
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import techcourse.fakebook.controller.utils.SessionUser;
@@ -42,13 +41,13 @@ public class ArticleApiController {
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<ArticleResponse> delete(@PathVariable Long id, @SessionUser UserOutline userOutline) {
+    public ResponseEntity<Void> delete(@PathVariable Long id, @SessionUser UserOutline userOutline) {
         articleService.deleteById(id, userOutline);
         return ResponseEntity.noContent().build();
     }
 
     @GetMapping("/{id}/like")
-    public ResponseEntity<HttpStatus> checkLike(@PathVariable Long id, @SessionUser UserOutline userOutline) {
+    public ResponseEntity<Void> checkLike(@PathVariable Long id, @SessionUser UserOutline userOutline) {
         if (articleService.isLiked(id, userOutline)) {
             return ResponseEntity.ok().build();
         }
@@ -56,7 +55,7 @@ public class ArticleApiController {
     }
 
     @PostMapping("/{id}/like")
-    public ResponseEntity<HttpStatus> like(@PathVariable Long id, @SessionUser UserOutline userOutline) {
+    public ResponseEntity<Void> like(@PathVariable Long id, @SessionUser UserOutline userOutline) {
         articleService.like(id, userOutline);
         if (articleService.isLiked(id, userOutline)) {
             return ResponseEntity.created(URI.create("/api/articles/" + id + "/like")).build();

--- a/src/main/java/techcourse/fakebook/controller/CommentApiController.java
+++ b/src/main/java/techcourse/fakebook/controller/CommentApiController.java
@@ -1,6 +1,5 @@
 package techcourse.fakebook.controller;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import techcourse.fakebook.controller.utils.SessionUser;
@@ -40,13 +39,13 @@ public class CommentApiController {
     }
 
     @DeleteMapping("/comments/{commentId}")
-    public ResponseEntity<CommentResponse> delete(@PathVariable Long commentId, @SessionUser UserOutline userOutline) {
+    public ResponseEntity<Void> delete(@PathVariable Long commentId, @SessionUser UserOutline userOutline) {
         commentService.deleteById(commentId, userOutline);
         return ResponseEntity.noContent().build();
     }
 
     @GetMapping("/comments/{commentId}/like")
-    public ResponseEntity<HttpStatus> checkLike(@PathVariable Long commentId, @SessionUser UserOutline userOutline) {
+    public ResponseEntity<Void> checkLike(@PathVariable Long commentId, @SessionUser UserOutline userOutline) {
         if (commentService.isLiked(commentId, userOutline)) {
             return ResponseEntity.ok().build();
         }
@@ -54,7 +53,7 @@ public class CommentApiController {
     }
 
     @PostMapping("/comments/{commentId}/like")
-    public ResponseEntity<HttpStatus> like(@PathVariable Long commentId, @SessionUser UserOutline userOutline) {
+    public ResponseEntity<Void> like(@PathVariable Long commentId, @SessionUser UserOutline userOutline) {
         commentService.like(commentId, userOutline);
         if (commentService.isLiked(commentId, userOutline)) {
             return ResponseEntity.created(URI.create("/api/comments/" + commentId + "/like")).build();

--- a/src/main/java/techcourse/fakebook/controller/CommentApiController.java
+++ b/src/main/java/techcourse/fakebook/controller/CommentApiController.java
@@ -29,7 +29,7 @@ public class CommentApiController {
     @PostMapping("/articles/{articleId}/comments")
     public ResponseEntity<CommentResponse> create(@PathVariable Long articleId, @RequestBody CommentRequest commentRequest, @SessionUser UserOutline userOutline) {
         CommentResponse commentResponse = commentService.save(articleId, commentRequest, userOutline);
-        return ResponseEntity.created(URI.create("/api/articles/" + articleId + "/comments")).body(commentResponse);
+        return ResponseEntity.created(URI.create("/api/articles/" + articleId + "/comments/" + commentResponse.getId())).body(commentResponse);
     }
 
     @PutMapping("/comments/{commentId}")

--- a/src/main/java/techcourse/fakebook/controller/CommentApiController.java
+++ b/src/main/java/techcourse/fakebook/controller/CommentApiController.java
@@ -14,7 +14,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/api")
 public class CommentApiController {
-    private CommentService commentService;
+    private final CommentService commentService;
 
     public CommentApiController(CommentService commentService) {
         this.commentService = commentService;

--- a/src/main/java/techcourse/fakebook/controller/FriendshipApiController.java
+++ b/src/main/java/techcourse/fakebook/controller/FriendshipApiController.java
@@ -2,7 +2,6 @@ package techcourse.fakebook.controller;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -26,7 +25,7 @@ public class FriendshipApiController {
     }
 
     @PostMapping
-    public ResponseEntity<HttpStatus> create(@RequestBody FriendshipRequest friendshipRequest, @SessionUser UserOutline userOutline) {
+    public ResponseEntity<Void> create(@RequestBody FriendshipRequest friendshipRequest, @SessionUser UserOutline userOutline) {
         log.debug("begin");
 
         log.debug("friendshipRequest: {}", friendshipRequest);

--- a/src/main/java/techcourse/fakebook/service/ArticleService.java
+++ b/src/main/java/techcourse/fakebook/service/ArticleService.java
@@ -31,11 +31,11 @@ public class ArticleService {
     private static final String DEFAULT_PATH = "src/main/resources/static";
     private static final String ARTICLE_STATIC_FILE_PATH = "file/article/";
 
-    private ArticleRepository articleRepository;
-    private ArticleLikeRepository articleLikeRepository;
-    private UserService userService;
-    private ArticleAssembler articleAssembler;
-    private ArticleMultipartRepository articleMultipartRepository;
+    private final ArticleRepository articleRepository;
+    private final ArticleLikeRepository articleLikeRepository;
+    private final UserService userService;
+    private final ArticleAssembler articleAssembler;
+    private final ArticleMultipartRepository articleMultipartRepository;
 
     public ArticleService(ArticleRepository articleRepository, ArticleLikeRepository articleLikeRepository, UserService userService, ArticleAssembler articleAssembler, ArticleMultipartRepository articleMultipartRepository) {
         this.articleRepository = articleRepository;

--- a/src/main/java/techcourse/fakebook/service/CommentService.java
+++ b/src/main/java/techcourse/fakebook/service/CommentService.java
@@ -22,11 +22,11 @@ import java.util.stream.Collectors;
 @Service
 @Transactional
 public class CommentService {
-    private ArticleService articleService;
-    private UserService userService;
-    private CommentRepository commentRepository;
-    private CommentLikeRepository commentLikeRepository;
-    private CommentAssembler commentAssembler;
+    private final ArticleService articleService;
+    private final UserService userService;
+    private final CommentRepository commentRepository;
+    private final CommentLikeRepository commentLikeRepository;
+    private final CommentAssembler commentAssembler;
 
     public CommentService(ArticleService articleService, UserService userService,
                           CommentRepository commentRepository, CommentLikeRepository commentLikeRepository, CommentAssembler commentAssembler) {

--- a/src/main/java/techcourse/fakebook/service/TotalService.java
+++ b/src/main/java/techcourse/fakebook/service/TotalService.java
@@ -9,9 +9,9 @@ import java.util.stream.Collectors;
 
 @Service
 public class TotalService {
-    private ArticleService articleService;
-    private CommentService commentService;
-    private ArticleAssembler articleAssembler;
+    private final ArticleService articleService;
+    private final CommentService commentService;
+    private final ArticleAssembler articleAssembler;
 
     public TotalService(ArticleService articleService, CommentService commentService, ArticleAssembler articleAssembler) {
         this.articleService = articleService;

--- a/src/test/java/techcourse/fakebook/controller/ArticleApiControllerTest.java
+++ b/src/test/java/techcourse/fakebook/controller/ArticleApiControllerTest.java
@@ -3,6 +3,7 @@ package techcourse.fakebook.controller;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import techcourse.fakebook.service.dto.ArticleRequest;
 import techcourse.fakebook.service.dto.ArticleResponse;
@@ -36,7 +37,7 @@ public class ArticleApiControllerTest extends ControllerTestHelper {
         when().
                 get("/api/articles").
         then().
-                statusCode(200).
+                statusCode(HttpStatus.OK.value()).
                 extract().
                 body().
                 jsonPath().getList(".", ArticleResponse.class);
@@ -55,7 +56,7 @@ public class ArticleApiControllerTest extends ControllerTestHelper {
         when().
                 post("/api/articles").
         then().
-                statusCode(201).
+                statusCode(HttpStatus.CREATED.value()).
                 body("content", equalTo(articleRequest.getContent()));
     }
 
@@ -67,7 +68,7 @@ public class ArticleApiControllerTest extends ControllerTestHelper {
         when().
                 delete("/api/articles/2").
         then().
-                statusCode(204);
+                statusCode(HttpStatus.NO_CONTENT.value());
     }
 
     @Test
@@ -82,7 +83,7 @@ public class ArticleApiControllerTest extends ControllerTestHelper {
         when().
                 put("/api/articles/1").
         then().
-                statusCode(200).
+                statusCode(HttpStatus.OK.value()).
                 body("content", equalTo(articleRequest.getContent()));
     }
 
@@ -96,7 +97,7 @@ public class ArticleApiControllerTest extends ControllerTestHelper {
         when().
                 get("api/articles/" + article.getId() + "/like").
         then().
-                statusCode(204);
+                statusCode(HttpStatus.NO_CONTENT.value());
     }
 
     @Test
@@ -109,7 +110,7 @@ public class ArticleApiControllerTest extends ControllerTestHelper {
         when().
                 post("/api/articles/" + article.getId() + "/like").
         then().
-                statusCode(201);
+                statusCode(HttpStatus.CREATED.value());
     }
 
     @Test
@@ -122,7 +123,7 @@ public class ArticleApiControllerTest extends ControllerTestHelper {
         when().
                 post("/api/articles/" + article.getId() + "/like").
         then().
-                statusCode(201);
+                statusCode(HttpStatus.CREATED.value());
 
         given().
                 port(port).
@@ -130,7 +131,7 @@ public class ArticleApiControllerTest extends ControllerTestHelper {
         when().
                 post("/api/articles/" + article.getId() + "/like").
         then().
-                statusCode(204);
+                statusCode(HttpStatus.NO_CONTENT.value());
     }
 
     @Test
@@ -145,7 +146,7 @@ public class ArticleApiControllerTest extends ControllerTestHelper {
         when().
                 post("/api/articles/" + articleResponse.getId() + "/like").
         then().
-                statusCode(201);
+                statusCode(HttpStatus.CREATED.value());
 
         given().
                 port(port).
@@ -153,7 +154,7 @@ public class ArticleApiControllerTest extends ControllerTestHelper {
         when().
                 get("/api/articles/" + articleResponse.getId() + "/like/count").
         then().
-                statusCode(200).
+                statusCode(HttpStatus.OK.value()).
                 body(equalTo("1"));
     }
 

--- a/src/test/java/techcourse/fakebook/controller/CommentApiControllerTest.java
+++ b/src/test/java/techcourse/fakebook/controller/CommentApiControllerTest.java
@@ -3,6 +3,7 @@ package techcourse.fakebook.controller;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import techcourse.fakebook.service.dto.ArticleResponse;
 import techcourse.fakebook.service.dto.CommentRequest;
@@ -34,7 +35,7 @@ public class CommentApiControllerTest extends ControllerTestHelper {
         when().
                 get("/api/articles/1/comments").
         then().
-                statusCode(200).
+                statusCode(HttpStatus.OK.value()).
                 extract().
                 body().
                 jsonPath().getList(".", CommentResponse.class);
@@ -54,7 +55,7 @@ public class CommentApiControllerTest extends ControllerTestHelper {
         when().
                 post("/api/articles/1/comments").
         then().
-                statusCode(201).
+                statusCode(HttpStatus.CREATED.value()).
                 body("content", equalTo(commentRequest.getContent()));
     }
 
@@ -66,7 +67,7 @@ public class CommentApiControllerTest extends ControllerTestHelper {
         when().
                 delete("/api/comments/2").
         then().
-                statusCode(204);
+                statusCode(HttpStatus.NO_CONTENT.value());
     }
 
     @Test
@@ -81,7 +82,7 @@ public class CommentApiControllerTest extends ControllerTestHelper {
         when().
                 put("/api/comments/1").
         then().
-                statusCode(200).
+                statusCode(HttpStatus.OK.value()).
                 body("content", equalTo(commentRequest.getContent()));
     }
 
@@ -95,7 +96,7 @@ public class CommentApiControllerTest extends ControllerTestHelper {
         when().
                 get("/api/comments/" + comment.getId() + "/like").
         then().
-                statusCode(204);
+                statusCode(HttpStatus.NO_CONTENT.value());
     }
 
     @Test
@@ -108,7 +109,7 @@ public class CommentApiControllerTest extends ControllerTestHelper {
         when().
                 post("/api/comments/" + comment.getId() + "/like").
         then().
-                statusCode(201);
+                statusCode(HttpStatus.CREATED.value());
     }
 
     @Test
@@ -121,7 +122,7 @@ public class CommentApiControllerTest extends ControllerTestHelper {
         when().
                 post("/api/comments/" + comment.getId() + "/like").
         then().
-                statusCode(201);
+                statusCode(HttpStatus.CREATED.value());
 
         given().
                 port(port).
@@ -129,7 +130,7 @@ public class CommentApiControllerTest extends ControllerTestHelper {
         when().
                 post("/api/comments/" + comment.getId() + "/like").
         then().
-                statusCode(204);
+                statusCode(HttpStatus.NO_CONTENT.value());
     }
 
     @Test
@@ -143,7 +144,7 @@ public class CommentApiControllerTest extends ControllerTestHelper {
         when().
                 post("/api/comments/" + commentResponse.getId() + "/like").
         then().
-                statusCode(201);
+                statusCode(HttpStatus.CREATED.value());
 
 
         given().
@@ -152,7 +153,7 @@ public class CommentApiControllerTest extends ControllerTestHelper {
         when().
                 get("/api/comments/" + commentResponse.getId() + "/like/count").
         then().
-                statusCode(200).
+                statusCode(HttpStatus.OK.value()).
                 body(equalTo("1"));
     }
 
@@ -166,7 +167,7 @@ public class CommentApiControllerTest extends ControllerTestHelper {
         when().
                 get("/api/articles/" + articleResponse.getId() + "/comments/count").
         then().
-                statusCode(200).
+                statusCode(HttpStatus.OK.value()).
                 body(equalTo("1"));
     }
 

--- a/src/test/java/techcourse/fakebook/controller/UserApiControllerTest.java
+++ b/src/test/java/techcourse/fakebook/controller/UserApiControllerTest.java
@@ -2,6 +2,7 @@ package techcourse.fakebook.controller;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import techcourse.fakebook.service.dto.UserSignupRequest;
 import techcourse.fakebook.service.dto.UserUpdateRequest;
@@ -31,7 +32,7 @@ class UserApiControllerTest extends ControllerTestHelper {
         when().
                 put("/api/users/" + userId).
         then().
-                statusCode(200).
+                statusCode(HttpStatus.OK.value()).
                 body("coverUrl", equalTo(userUpdateRequest.getCoverUrl())).
                 body("introduction", equalTo(userUpdateRequest.getIntroduction()));
     }
@@ -52,7 +53,7 @@ class UserApiControllerTest extends ControllerTestHelper {
         when().
                 put("/api/users/" + userId).
         then().
-                statusCode(302);
+                statusCode(HttpStatus.FOUND.value());
     }
 
     @Test
@@ -61,14 +62,14 @@ class UserApiControllerTest extends ControllerTestHelper {
                 new UserSignupRequest("aa@bb.cc", "keyword", "123", "1q2w3e$R", "M", "123456");
         String cookie = getCookie(signup(userSignupRequest));
 
-                given().
-                        port(port).
-                        cookie(cookie).
-                        accept(MediaType.APPLICATION_JSON_UTF8_VALUE).
-                when().
-                        get("/api/users/" + "keyword").
-                then().
-                        statusCode(200).
-                        body(".", hasItem("keyword123"));
+        given().
+                port(port).
+                cookie(cookie).
+                accept(MediaType.APPLICATION_JSON_UTF8_VALUE).
+        when().
+                get("/api/users/" + "keyword").
+        then().
+                statusCode(HttpStatus.OK.value()).
+                body(".", hasItem("keyword123"));
     }
 }


### PR DESCRIPTION
issue #75 

피드백을 반영하여 컨트롤러를 리팩토링하였습니다.

1. ResponseEntity의 바디가 없는 경우 제네릭을 Void로 수정하였습니다.
2. HttpStatus enum을 사용하여 테스트 가독성을 향상하였습니다.
3. ResponseEntity에 제공하는 URI를, 생성된 자원을 참조할 수 있는 URI로 수정하였습니다.